### PR TITLE
Fix join query

### DIFF
--- a/src/Repositories/RegionRepository.php
+++ b/src/Repositories/RegionRepository.php
@@ -126,8 +126,8 @@ class RegionRepository implements RegionRepositoryContract
             $this->getStructProvince($q, $column, null, $region)
                 ->join('regions AS city', function ($query) {
                     return $query->on('province.id', 'city.parent_id')
-                        ->on('province.category_id', '1')
-                        ->on('city.category_id', '2');
+                        ->where('province.category_id', 1)
+                        ->where('city.category_id', 2);
                 })->when(!is_null($q), function ($query) use ($q) {
                     return $query
                         ->orWhere('city.name', 'LIKE', '%' . $q . '%');
@@ -155,7 +155,7 @@ class RegionRepository implements RegionRepositoryContract
         return $this->getStructCity($q, $column, null, $region)
             ->join('regions AS district', function ($query) {
                 return $query->on('district.parent_id', 'city.id')
-                    ->on('district.category_id', '3');
+                    ->where('district.category_id', 3);
             })->when(!is_null($q), function ($query) use ($q) {
                 return $query
                     ->orWhere('district.name', 'LIKE', '%' . $q . '%');
@@ -181,7 +181,7 @@ class RegionRepository implements RegionRepositoryContract
         return $this->getStructDistrict($q, $sub_district, null, $region)
             ->join('regions AS sub_district', function ($query) {
                 return $query->on('district.id', 'sub_district.parent_id')
-                    ->on('sub_district.category_id', '4');
+                    ->where('sub_district.category_id', 4);
             })->when(!is_null($q), function ($query) use ($q) {
                 return $query
                     ->orWhere('sub_district.name', 'LIKE', '%' . $q . '%');


### PR DESCRIPTION
The query inside `RegionRepository` causing error column not found as in the image below.
![Screen Shot 2019-06-25 at 00 11 12](https://user-images.githubusercontent.com/914534/60183610-d16e8e80-9850-11e9-9d15-32120bdd484e.png)

The fix is as mentioned on docs by using `where`, instead of `on`; when the joining query is using a fixed value as the comparison. See: https://laravel.com/docs/5.5/queries#joins on **Advanced Join Clauses**.
